### PR TITLE
Avoid expression closures which are deprecated

### DIFF
--- a/lib/forcertl.js
+++ b/lib/forcertl.js
@@ -197,13 +197,17 @@ exports.ForceRTL = Class({
     Prefs.on("rtl", onPrefChange);
     switchMode(this.dir);
   },
-  get enabled() Prefs.prefs.rtl,
-  get dir() this.enabled ? "rtl" : "ltr",
+  get enabled() {
+    return Prefs.prefs.rtl;
+  },
+  get dir() {
+    return this.enabled ? "rtl" : "ltr"
+  },
   toggle: function(callback) {
     gToggleCallbacks.push(callback);
     Prefs.prefs.rtl = !this.enabled;
   },
-  dispose: () => {
+  dispose() {
     Prefs.removeListener("rtl", onPrefChange);
     if (gObservingWindows) {
       let ww = Cc["@mozilla.org/embedcomp/window-watcher;1"]


### PR DESCRIPTION
This is throwing warnings on Nightly. Same for some of the modules this is using (pathfinder and menuitem).
