### PR TITLE
fix #5: call nextNode() only once per iteration in changeChromeDirInDoc

### DIFF
--- a/lib/forcertl.js
+++ b/lib/forcertl.js
@@ -177,7 +177,6 @@ const changeChromeDirInDoc = function(doc, dir) {
           node.setAttribute("dir", dir);
         }
       }
-      walker.nextNode();
     } while (node = walker.nextNode());
   }
 };


### PR DESCRIPTION
Avoids calling nextNode() twice.
