### PR TITLE
support intl.uidirection pref from new intl api

### DIFF
--- a/lib/forcertl.js
+++ b/lib/forcertl.js
@@ -14,6 +14,8 @@ const kAppIDFirefox = "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}";
 const kAppIDThunderbird = "{3550f703-e582-4d05-9a08-453d09bdfdc6}";
 const kIsMozLocaleDirSupported = kAppID == kAppIDThunderbird || kAppID == kAppIDFirefox;
 const kLocaleDirPrefPrefix = "intl.uidirection.";
+const kIntlDirPref = "intl.uidirection";
+
 let gLocaleDirPref = null;
 
 let gToggleCallbacks = [];
@@ -24,7 +26,7 @@ const switchMode = dir => {
       switchStyleSheet(dir) &&
       changeChromeDir(dir)) {
     if (kIsMozLocaleDirSupported && gLocaleDirPref) {
-      require("sdk/preferences/service").set(gLocaleDirPref, dir);
+      updatePreferences(dir);
     }
   }
   invokeCallbacks();
@@ -75,6 +77,20 @@ const changeChromeDir = function(dir) {
   }
 
   return true;
+}
+
+const updatePreferences = function (dir) {
+  let prefs = require("sdk/preferences/service");
+
+  let uiDirection = prefs.get("intl.uidirection");
+  let hasIntlApiEnabled = [-1, 0, 1].includes(uiDirection);
+  if (hasIntlApiEnabled) {
+    // The new intl API replaced intl.uidirection.* preferences with a single pref
+    // 1 forces RTL, -1 uses the locale's dir (default value).
+    prefs.set(kIntlDirPref, dir === "rtl" ? 1 : -1);
+  } else {
+    prefs.set(gLocaleDirPref, dir);
+  }
 }
 
 const windowWatcherObserver = function(aSubject, aTopic, aData) {


### PR DESCRIPTION
Force RTL no longer works after https://bugzilla.mozilla.org/show_bug.cgi?id=1312049 

This PR updates forcertl.js to use the appropriate preference when needed.